### PR TITLE
PEP 725: Fix example using `project.optional-dependencies`

### DIFF
--- a/pep-0725.rst
+++ b/pep-0725.rst
@@ -391,8 +391,8 @@ NAVis 1.4.0:
 
 .. code:: toml
 
-    [project]
-    optional-dependencies = ["rpy2"]
+    [project.optional-dependencies]
+    r = ["rpy2"]
 
     [external]
     build-requires = [


### PR DESCRIPTION
Correct the syntax used to specify optional runtime Python dependencies.

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--2.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->